### PR TITLE
[Partial][refactor] Dbize Benchhub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.0.3
+
+
+
+## 0.0.2
+
+A not working release, tagged due to major change in future release
+
+- central and agent talk using grpc (no streaming)
+- use a in memory store to store materialized data
+  - the schema is still quite messy
+- spec using YAML, struct generated using protobuf
+- runner for docker and shell commands

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,6 +4,7 @@
 
 ## Develop
 
+- [ ] TODO: most files under `doc` folder directly should be moved to legacy or `doc/dev`
 - [environment setup](dev-env.md) required runtime and how to install them
 - [directory layout](directory.md) what every folder (package does)
 - [flow](flow.md) life cycle of job, agent and central

--- a/doc/dev/overview.md
+++ b/doc/dev/overview.md
@@ -1,0 +1,54 @@
+# Overview of BenchHub
+
+BenchHub is a service for running database benchmark, result of benchmark is stored in database instead of plain text,
+further more, BenchHub service is written as if it is a database.
+
+## Terminology
+
+Some naming in BenchHub is not very straight forward due to historical reason
+
+- Central: master node
+- Agent: worker node
+- Spec: benchmark job specification, consider it as `.travis.yml`, it's not RFC
+- Artifact: files like binary, dataset, config, report, git repo etc.
+
+## Components
+
+- Central
+  - api server: talks with client and agent
+  - scheduler: assign node base on job spec
+  - planner: generate execution plan base on job spec
+  - executor: dispatch plan to agents, monitor responses from agents
+  - estimator: give user cost estimation before run the actual job so they can cancel it 
+- Agent
+  - executor: run plan got from central, start new process/container/vm
+  - monitor: collect metrics, and tag/create new series running plan
+- UI
+  - a single tenant UI, though it does have route for login ...
+- Cli
+  - tool for submit job 
+
+## Packages
+
+NOTE: it may not reflect current package layout 
+
+- lib
+  - benchmark, wrapper/implementation for benchmark suite
+  - monitor, use `/proc` to monitor host, use docker client to monitor container (might just use cgroup)
+  - waitforit
+- pkg/bhpb types defined using protobuf
+- pkg/central central only logic
+- pkg/agent agent only logic
+- pkg/scheduler scheduler
+- pkg/estimator estimator
+- pkg/planner 
+- pkg/executor 
+- pkg/runner spawn process and container
+
+## Limitations
+
+- no fail over for master
+- scheduler is a simple FIFO for single tenant
+  - need to change when becomes multi tenant
+  - even for single tenant, it may not be optimal to schedule job in the order they came
+  - also requires better implementation in estimator to aid scheduling in multi tenant mode

--- a/doc/dev/overview.md
+++ b/doc/dev/overview.md
@@ -35,15 +35,15 @@ NOTE: it may not reflect current package layout
 - lib
   - benchmark, wrapper/implementation for benchmark suite
   - monitor, use `/proc` to monitor host, use docker client to monitor container (might just use cgroup)
-  - waitforit
+  - waitforit, wait until a tcp port or http endpoint is ready
 - pkg/bhpb types defined using protobuf
 - pkg/central central only logic
 - pkg/agent agent only logic
 - pkg/scheduler scheduler
 - pkg/estimator estimator
-- pkg/planner 
-- pkg/executor 
-- pkg/runner spawn process and container
+- pkg/planner expand job spec to plan
+- pkg/executor execute plan locally or in remote
+- pkg/runner spawn process and container, maybe vm in the future
 
 ## Limitations
 

--- a/doc/legacy/roadmap-winter18.md
+++ b/doc/legacy/roadmap-winter18.md
@@ -1,0 +1,32 @@
+# Roadmap
+
+Previously deprecated roadmap before [UCSC Winter 2018](roadmap.md)
+
+## 0.1
+
+- use push style without retry, the whole job won't work if their is a single call goes wrong
+  - central call agent directly instead of agent pull from central or watch store
+  - agent call central directly after a task is finished
+- use state machine to keep an updated view in memory for central and agent
+- use pub/sub to record updates into store
+
+## 0.2
+
+- use push + pull, push is to notify event right away, pull (during heartbeat) will tell the state eventually
+
+## 0.3
+
+- works with other scheduler, i.e. Mesos, Kubernetes so it can run along side existing infrastructure
+
+## 0.4
+
+- github integration
+
+## 0.5
+
+- multi tenant
+- cost estimator
+
+## 0.6
+
+- benchboard, non database benchmark, i.e. go's benchmark, jmh etc.

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -1,30 +1,19 @@
 # Roadmap
 
-## 0.1
+Previous deprecated roadmap in [UCSC Winter 2018](legacy/roadmap-winter18.md)
 
-- use push style without retry, the whole job won't work if their is a single call goes wrong
-  - central call agent directly instead of agent pull from central or watch store
-  - agent call central directly after a task is finished
-- use state machine to keep an updated view in memory for central and agent
-- use pub/sub to record updates into store
+## 0.0.3
 
-## 0.2
+Structure BenchHub itself like a database
+ 
+- state of the cluster can be considered as schema stored in catalog
+- checking and populating benchmark spec is like validating and expanding SQL statement
+- scheduling nodes is like data placement and cost estimation
+- executing benchmark spec is like execute SQL statement (except most benchmark runs much longer)
+- the dependencies between stages among multiple nodes is like 2PC
+- benchhub can also be seen as a proxy for meta and time series store
 
-- use push + pull, push is to notify event right away, pull (during heartbeat) will tell the state eventually
+## 0.0.2
 
-## 0.3
-
-- works with other scheduler, i.e. Mesos, Kubernetes so it can run along side existing infrastructure
-
-## 0.4
-
-- github integration
-
-## 0.5
-
-- multi tenant
-- cost estimator
-
-## 0.6
-
-- benchboard, non database benchmark, i.e. go's benchmark, jmh etc.
+- old client server style design, most components are finished, but are not well linked together
+- the schema for store is still quite a mess

--- a/doc/survey/scheduler/ali.md
+++ b/doc/survey/scheduler/ali.md
@@ -1,0 +1,48 @@
+# Alibaba
+
+- Fuxi https://github.com/gaocegege/papers-notebook/issues/19
+- https://edu.aliyun.com/course/31
+  - by @gaocegege '阿里的分布式调度课程，讲的说实话很好了'
+  - client -> fuxi master -> app master -> app worker
+  - app master 
+    - require resource from fuxi master
+    - start app worker on node
+    - monitor job, retry
+  - app worker
+    - just run and store result
+  - job scheduling
+    - run job, monitor, restart etc.
+    - locality?
+  - resource scheduling
+    - priority
+    - 抢占 ...
+    - fair scheduling, multiple groups based on priority
+    - quota, group jobs, fuxi would change quota dynamically
+       - make sharable resource cheaper
+       - make dedicated resource more expensive
+       - **it's a bill management system** 
+  - fault tolerance
+    - job scheduling
+      - app worker, retry on another app worker
+    - resource scheduling
+      - soft state (recover from other components)
+        - ask app master and tubo to send snapshot of state
+      - hard state (i.e. job config)
+        - check point
+  - scale
+    - multi thread, on app master, use different thread pools, one for fuximaster (more import & less node), one for tubo
+    - incremental, (keep memory of app master in fuxi master)
+  - security
+    - static: encrypt messages
+    - dynamic: token from authority
+    - sandbox in tubo when start worker
+  - isolation
+    - vm (KVM), best isolation
+    - docker
+    - lxc
+  - future
+    - mix of online and offline
+    - real-time compute, storm, spark
+    - larger scale
+      - time
+      - resource

--- a/doc/survey/scheduler/bistro.md
+++ b/doc/survey/scheduler/bistro.md
@@ -3,3 +3,15 @@
 - https://github.com/gaocegege/papers-notebook/issues/6
 - https://github.com/facebook/bistro for batch processing
 - http://facebook.github.io/bistro/docs/overview-of-concepts/
+
+Scheduler
+
+- long tail
+- randomize priority
+- round robin
+
+Runners
+
+- noop
+- local
+- remote

--- a/doc/survey/scheduler/bistro.md
+++ b/doc/survey/scheduler/bistro.md
@@ -1,0 +1,5 @@
+# Facebook Bistro
+
+- https://github.com/gaocegege/papers-notebook/issues/6
+- https://github.com/facebook/bistro for batch processing
+- http://facebook.github.io/bistro/docs/overview-of-concepts/

--- a/p2/README.md
+++ b/p2/README.md
@@ -1,0 +1,4 @@
+# P2
+
+`p2` is temporary package name during refactor, will be renamed to `pkg` after old code is removed entirely
+

--- a/p2/bhpb/pkg.go
+++ b/p2/bhpb/pkg.go
@@ -1,0 +1,3 @@
+// Package bhpb is generated using gogoprotobuf, it also contains the proto file
+// TODO: we might just generate the proto file instead of writing in protobuf, write the proto definition in go code directly
+package bhpb


### PR DESCRIPTION
Ref #50 

Planning to restructure BenchHub so the service itself is structured like a database, there are things need to be solved before starting the implementation

- [ ] schema management, it's a pain to use grpc (protobuf) for http server and angular client, it need to be solved in go.ice
- [ ] fe-template will come out with a template for login, dashboard etc. and benchhub's existing front end code (almost nothing) will be merged into that
- [ ] gommon is having refactor after update on its example etc.
- [ ] issue labels across projects